### PR TITLE
Add rootfiles-maven-plugin

### DIFF
--- a/utils/rootfiles-maven-plugin/.classpath
+++ b/utils/rootfiles-maven-plugin/.classpath
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-10">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/utils/rootfiles-maven-plugin/.gitignore
+++ b/utils/rootfiles-maven-plugin/.gitignore
@@ -1,0 +1,2 @@
+out/
+target/

--- a/utils/rootfiles-maven-plugin/.project
+++ b/utils/rootfiles-maven-plugin/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>rootfiles-maven-plugin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/utils/rootfiles-maven-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/utils/rootfiles-maven-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=10
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=10
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=10

--- a/utils/rootfiles-maven-plugin/.settings/org.eclipse.m2e.core.prefs
+++ b/utils/rootfiles-maven-plugin/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/utils/rootfiles-maven-plugin/README.md
+++ b/utils/rootfiles-maven-plugin/README.md
@@ -1,0 +1,44 @@
+# rootfiles-maven-plugin
+
+## The Issue
+
+When deploying an OSGi Feature with rootfiles to a maven repository (e.g. Github Packages), `root`-files are deployed separately (as another maven artifact with classifier `root` and type `zip`). When importing the feature within a target platform (via the m2e maven target support), the root files are not being downloaded.
+
+## The Workaround
+
+This minimal maven plugin allows to download the root files for a deployed root feature. The downloaded files can then be added to a new feature as root files
+
+### Usage
+
+The following example downloads the latest Eclipse SET feature root files into the local `rootdir_set` folder.
+
+```xml
+<plugin>
+    <groupId>org.eclipse.set</groupId>
+	<artifactId>rootfiles-maven-plugin</artifactId>
+	<version>1.0.0</version>
+	<executions>
+	    <execution>
+		    <id>fetch-set-feature</id>
+			<goals>
+			    <goal>fetch</goal>
+			</goals>
+			<configuration>
+                <serverId>github-set</serverId>
+                <serverUrl>https://maven.pkg.github.com/eclipse-set/set</serverUrl>
+                <groupId>org.eclipse.set</groupId>
+                <artifactId>org.eclipse.set.feature</artifactId>
+                <version>2.1.0-SNAPSHOT</version>
+                <outPath>${basedir}/rootdir_set</outPath>
+            </configuration>
+	    </execution>
+    <executions>
+</plugin>
+```
+
+### Parameters
+
+- serverId: The maven server id to use for retrieving the artifact.
+- serverUrl: The maven server url to use for retrieving the artifact.
+- groupId/artifactId/version: The GAV for the artifact to fetch.
+- outPath: Output directory for extracted files

--- a/utils/rootfiles-maven-plugin/pom.xml
+++ b/utils/rootfiles-maven-plugin/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.eclipse.set</groupId>
+    <artifactId>rootfiles-maven-plugin</artifactId>
+    <version>1.0.0</version>
+    <packaging>maven-plugin</packaging>
+
+    <properties>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.9.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.9.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.9.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.6.0</version>
+        </dependency>
+    </dependencies>
+    <distributionManagement>
+        <repository>
+            <id>set-github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/eclipse-set/build</url>
+        </repository>
+    </distributionManagement>
+</project>

--- a/utils/rootfiles-maven-plugin/src/main/java/org/eclipse/set/planpromavenplugin/MavenRootfilesMojo.java
+++ b/utils/rootfiles-maven-plugin/src/main/java/org/eclipse/set/planpromavenplugin/MavenRootfilesMojo.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2023 DB Netz AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+package org.eclipse.set.rootfilesmavenplugin;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.repository.RepositorySystem;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResult;
+
+@Mojo(name = "fetch", requiresProject = false, threadSafe = true, defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public class MavenRootfilesMojo extends AbstractMojo {
+	@Parameter(defaultValue = "${session}", required = true, readonly = true)
+	private MavenSession session;
+	
+	@Component
+	private ArtifactResolver artifactResolver;
+
+	@Component
+	private ArtifactHandlerManager artifactHandlerManager;
+
+	@Component(role = ArtifactRepositoryLayout.class)
+	private Map<String, ArtifactRepositoryLayout> repositoryLayouts;
+
+	@Component
+	private RepositorySystem repositorySystem;
+
+	@Parameter(property = "serverId", required = true)
+	private String serverId;
+
+	@Parameter(property = "serverUrl", required = true)
+	private String serverUrl;
+
+	@Parameter(property = "groupId", required = true)
+	private String groupId;
+
+	@Parameter(property = "artifactId", required = true)
+	private String artifactId;
+
+	@Parameter(property = "version", required = true)
+	private String version;
+
+	@Parameter(property = "outPath", required = true)
+	private String outPath;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		ArtifactRepositoryPolicy always = new ArtifactRepositoryPolicy(true,
+				ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS, ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN);
+
+		ArtifactRepositoryLayout layout = repositoryLayouts.get("default");
+		List<ArtifactRepository> repoList = List
+				.of(new MavenArtifactRepository(serverId, serverUrl, layout, always, always));
+
+		try {
+			ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(
+					session.getProjectBuildingRequest());
+
+			Settings settings = session.getSettings();
+			repositorySystem.injectMirror(repoList, settings.getMirrors());
+			repositorySystem.injectProxy(repoList, settings.getProxies());
+			repositorySystem.injectAuthentication(repoList, settings.getServers());
+
+			buildingRequest.setRemoteRepositories(repoList);
+
+			DefaultArtifactCoordinate coordinate = new DefaultArtifactCoordinate();
+			coordinate.setGroupId(groupId);
+			coordinate.setArtifactId(artifactId);
+			coordinate.setVersion(version);
+			coordinate.setClassifier("root");
+			coordinate.setExtension("zip");
+
+			getLog().info("Resolving " + coordinate);
+			ArtifactResult artifactResult = artifactResolver.resolveArtifact(buildingRequest, coordinate);
+
+			getLog().info("Extracting " + artifactResult.getArtifact().getFile().getAbsolutePath());
+			unzip(artifactResult.getArtifact().getFile(), new File(outPath));
+		} catch (ArtifactResolverException e) {
+			throw new MojoExecutionException("Couldn't download artifact: " + e.getMessage(), e);
+		} catch (IOException e) {
+			throw new MojoExecutionException("Couldn't extract artifact: " + e.getMessage(), e);
+		}
+	}
+
+	private void unzip(File zipFile, File outDir) throws IOException {
+		byte[] buffer = new byte[1024];
+
+		try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
+			ZipEntry zipEntry = zis.getNextEntry();
+			while (zipEntry != null) {
+				File newFile = new File(outDir, zipEntry.getName());
+				if (zipEntry.isDirectory()) {
+					if (!newFile.isDirectory() && !newFile.mkdirs()) {
+						throw new IOException("Failed to create directory " + newFile);
+					}
+				} else {
+					try (FileOutputStream fos = new FileOutputStream(newFile)) {
+						int len = 0;
+						while ((len = zis.read(buffer)) > 0) {
+							fos.write(buffer, 0, len);
+						}
+					}
+				}
+				zipEntry = zis.getNextEntry();
+			}
+			zis.closeEntry();
+		}
+	}
+
+}


### PR DESCRIPTION
When deploying an OSGi Feature with rootfiles to a maven repository (e.g. Github Packages), `root`-files are deployed separately (as another maven artifact with classifier `root` and type `zip`). When importing the feature within a target platform (via the m2e maven target support), the root files are not being downloaded.

This minimal maven plugin allows to download the root files for a deployed root feature. The downloaded files can then be added to a new feature as root files in the consuming product.
