### PR TITLE
Add reusable actions for release creation

### DIFF
--- a/.github/actions/set-version/action.yml
+++ b/.github/actions/set-version/action.yml
@@ -1,0 +1,45 @@
+name: 'Update version'
+description: 'Updates the version for the local maven repository as well as all Eclipse SET dependencies in the specified target platform'
+inputs:
+  version:
+    description: 'Release version. Format: <major>.<minor>.<patch>(.<tag>)'
+    required: true
+  target:
+    description: 'Path to target platform'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: temurin
+        server-id: set-github
+        cache: maven
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.3
+
+    - name: Set Maven Version
+      shell: bash
+      run: mvn -B tycho-versions:set-version -DnewVersion=${{ inputs.version }}
+
+    - name: Install xmlstarlet
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y xmlstarlet
+
+    - name: Update target platform
+      shell: bash
+      run: |
+        xmlstarlet ed --inplace \
+          -u "target/locations/location/dependencies/dependency[groupId='org.eclipse.set']/version" \
+          -v '${{ inputs.version }}' \
+          -u "/target/locations/location/repositories/repository/url[starts-with(., 'https://maven.pkg.github.com/eclipse-set/')]" \
+          -x 'concat("https://maven.pkg.github.com/${{ github.repository_owner }}/", substring-after(., "https://maven.pkg.github.com/eclipse-set/"))' \
+          ${{ inputs.target }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Push to Github
       run: |
         git config user.name 'eclipse-set-bot'
-        git config user.email '117744039+eclipse-set-bot@users.noreply.github.com'
+        git config user.email 'set-bot@eclipse.org'
         git status
         git branch -D release/${{ inputs.version }} || true
         git checkout -b release/${{ inputs.version }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,49 @@
+# This workflow will create a new release branch
+
+name: Release Branch
+    
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version. Format: <major>.<minor>'
+        type: string
+        required: true
+      target:
+        description: 'Path to target platform'
+        type: string
+        required: true
+
+jobs:
+  release-branch:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+    - name: Fail if branch is not main
+      if: github.ref != 'refs/heads/main'
+      run: |
+        echo "This workflow should not be triggered on a branch other than main"
+        exit 1
+        
+    - uses: actions/checkout@v3
+
+    - name: Bump versions
+      uses: eclipse-set/build/.github/actions/set-version@main
+      with:
+        version: ${{ inputs.version }}.0-SNAPSHOT
+        target: ${{ inputs.target }}
+     
+    - name: Push to Github
+      run: |
+        git config user.name 'eclipse-set-bot'
+        git config user.email '117744039+eclipse-set-bot@users.noreply.github.com'
+        git status
+        git branch -D release/${{ inputs.version }} || true
+        git checkout -b release/${{ inputs.version }}
+        git status
+        git add -A
+        git commit --allow-empty -m "Prepare development branch for ${{ inputs.version }}" 
+        git status
+        git push -f -u origin release/${{ inputs.version }}
+        git status

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,49 @@
+# This workflow will create a new release tag
+
+name: Release Tag
+    
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version. Format: <major>.<minor>.<patch>(.tag)'
+        type: string
+        required: true
+      target:
+        description: 'Path to target platform'
+        type: string
+        required: true
+
+jobs:        
+  release-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Fail if branch is main
+      if: github.ref == 'refs/heads/main'
+      run: |
+        echo "This workflow should not be triggered on main"
+        exit 1
+    
+    - uses: actions/checkout@v3
+
+    - name: Bump versions
+      uses: eclipse-set/build/.github/actions/set-version@main
+      with:
+        version: ${{ inputs.version }}
+        target: ${{ inputs.target }}
+     
+    - name: Push to Github
+      run: |
+        git config user.name 'eclipse-set-bot'
+        git config user.email '117744039+eclipse-set-bot@users.noreply.github.com'
+        git status
+        git add -A
+        git commit --allow-empty -m "Release ${{ inputs.version }}" 
+        git status
+        git tag -d release/${{ inputs.version }} || true
+        git tag release/${{ inputs.version }}
+        git status
+        git push -f -u origin release/${{ inputs.version }}
+        git status

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Push to Github
       run: |
         git config user.name 'eclipse-set-bot'
-        git config user.email '117744039+eclipse-set-bot@users.noreply.github.com'
+        git config user.email 'set-bot@eclipse.org'
         git status
         git add -A
         git commit --allow-empty -m "Release ${{ inputs.version }}" 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -15,7 +15,7 @@ on:
         required: true
 
 jobs:        
-  release-branch:
+  release-tag:
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This adds two new actions for release branch and release tag creation to be reused across our repositories.