### PR TITLE
Add option to provide path to pom.xml to release workflows

### DIFF
--- a/.github/actions/set-version/action.yml
+++ b/.github/actions/set-version/action.yml
@@ -7,6 +7,10 @@ inputs:
   target:
     description: 'Path to target platform'
     required: true
+  pom:
+    description: 'Path to pom.xml'
+    required: false
+    default: 'pom.xml'
 
 runs:
   using: "composite"
@@ -26,7 +30,7 @@ runs:
 
     - name: Set Maven Version
       shell: bash
-      run: mvn -B tycho-versions:set-version -DnewVersion=${{ inputs.version }}
+      run: mvn -f ${{ inputs.pom }} -B tycho-versions:set-version -DnewVersion=${{ inputs.version }}
 
     - name: Install xmlstarlet
       shell: bash

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -13,6 +13,11 @@ on:
         description: 'Path to target platform'
         type: string
         required: true
+      pom:
+        description: 'Path to pom.xml. Defaults to pom.xml in working directory'
+        type: string
+        required: false
+        default: 'pom.xml'
 
 jobs:
   release-branch:
@@ -33,6 +38,7 @@ jobs:
       with:
         version: ${{ inputs.version }}.0-SNAPSHOT
         target: ${{ inputs.target }}
+        pom: ${{ inputs.pom }}
      
     - name: Push to Github
       run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -13,6 +13,11 @@ on:
         description: 'Path to target platform'
         type: string
         required: true
+      pom:
+        description: 'Path to pom.xml. Defaults to pom.xml in working directory'
+        type: string
+        required: false
+        default: 'pom.xml'
 
 jobs:        
   release-tag:
@@ -33,6 +38,7 @@ jobs:
       with:
         version: ${{ inputs.version }}
         target: ${{ inputs.target }}
+        pom: ${{ inputs.pom }}
      
     - name: Push to Github
       run: |


### PR DESCRIPTION
Previously the set-version action assumed the pom.xml to be in the root of the workspace. This adds an extra parameter to provide a specific path. 