### PR TITLE
Add reusable actions for Dash license checking

### DIFF
--- a/.github/actions/dash-license-check-action/action.yml
+++ b/.github/actions/dash-license-check-action/action.yml
@@ -1,0 +1,78 @@
+# *************************************************************************
+# * Copyright (c) 2022, 2023 Hannes Wellmann and others.
+# *
+# * This program and the accompanying materials are made available under
+# * the terms of the Eclipse Public License 2.0 which accompanies this
+# * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+# *
+# * SPDX-License-Identifier: EPL-2.0
+# *      Hannes Wellmann - initial API and implementation
+# *************************************************************************
+# Adapted from https://github.com/eclipse/dash-licenses/blob/master/.github/actions/maven-license-check-action/action.yml
+# for usage in Eclipse SET
+
+name: 'Check license vetting status'
+description: 'Checks if the licenses of all dependencies are vetted and requests a review in case required and wanted'
+inputs:
+  request-review:
+    description: ''
+    required: false
+  project-id:
+    description: ''
+    required: false
+  pom:
+    description: 'pom.xml path'
+    required: false
+    default: 'pom.xml'
+outputs:
+  licenses-vetted: 
+    description: "True if all licenses are vetted, else false"
+    value: ${{ steps.license-check-with-review-request.outputs.build-succeeded }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.9.3
+
+    - name: Process maven dependencies
+      shell: bash
+      run: mvn -f ${{ inputs.pom }} -U -B -ntp -Dtycho.target.eager=true dependency:list -DappendOutput=true -DoutputFile=${{ github.workspace }}/maven.deps
+      
+    - id: license-check-with-review-request
+      shell: bash {0} # do not fail-fast
+      run: |
+        wget -nv -O ../dash.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+        if [[ ${{ inputs.project-id }} != "" ]]; then
+          dashArgs+=" -project ${{ inputs.project-id }}"
+        fi
+        if [ ${{ inputs.request-review }} ]; then
+          java -jar ../dash.jar ${dashArgs} -summary DEPENDENCIES -review -token $GITLAB_API_TOKEN $(find . '(' -name "*.deps" -o -name "package-lock.json" ')' -type f -exec sh -c 'echo "$0"' {} \;)
+          if [[ $? == 0 ]]; then # All licenses are vetted
+            echo "build-succeeded=1" >> $GITHUB_OUTPUT
+          else
+            echo "build-succeeded=0" >> $GITHUB_OUTPUT
+          fi
+        else
+          java -jar ../dash.jar ${dashArgs} -summary DEPENDENCIES $(find . '(' -name "*.deps" -o -name "package-lock.json" ')' -type f -exec sh -c 'echo "$0"' {} \;)
+          if [[ $? == 0 ]]; then # All licenses are vetted
+            echo "build-succeeded=1" >> $GITHUB_OUTPUT
+          else
+            echo "build-succeeded=0" >> $GITHUB_OUTPUT
+          fi
+        fi

--- a/.github/actions/dash-license-check-action/action.yml
+++ b/.github/actions/dash-license-check-action/action.yml
@@ -46,7 +46,7 @@ runs:
           ${{ runner.os }}-maven-
 
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
       with:
         maven-version: 3.9.3
 

--- a/.github/actions/set-version/action.yml
+++ b/.github/actions/set-version/action.yml
@@ -43,3 +43,8 @@ runs:
           -u "/target/locations/location/repositories/repository/url[starts-with(., 'https://maven.pkg.github.com/eclipse-set/')]" \
           -x 'concat("https://maven.pkg.github.com/${{ github.repository_owner }}/", substring-after(., "https://maven.pkg.github.com/eclipse-set/"))' \
           ${{ inputs.target }}
+
+    - name: Update DEPENDENCIES
+      uses: eclipse-set/build/.github/actions/update-dependency-file@main
+      with:
+        pom: ${{ inputs.pom }}

--- a/.github/actions/update-dependency-file/action.yml
+++ b/.github/actions/update-dependency-file/action.yml
@@ -1,0 +1,34 @@
+name: 'Update DEPENDENCIES file'
+description: 'Updates the DEPENDENCIES file'
+inputs:
+  pom:
+    description: 'pom.xml path'
+    required: false
+    default: 'pom.xml'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: temurin
+        server-id: set-github
+        cache: maven
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.3
+
+    - name: Process maven dependencies
+      shell: bash
+      run: mvn -f ${{ inputs.pom }} -U -B -ntp -Dtycho.target.eager=true dependency:list -DappendOutput=true -DoutputFile=${{ github.workspace }}/maven.deps
+
+    - name: License check
+      shell: bash {0} # do not fail-fast
+      run: |
+        wget -nv -O ../dash.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+        java -jar ../dash.jar ${dashArgs} -summary DEPENDENCIES $(find . '(' -name "*.deps" -o -name "package-lock.json" ')' -type f -exec sh -c 'echo "$0"' {} \;)
+        rm -rf ${{ github.workspace }}/maven.deps

--- a/.github/workflows/dash.yml
+++ b/.github/workflows/dash.yml
@@ -102,7 +102,7 @@ jobs:
         GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
     
     # Hide outdated License comments
-    - uses: int128/hide-comment-action@5aa4ad6cf762098ebdc5d3c046e9e1fb35fe5ce8 # v1
+    - uses: int128/hide-comment-action@31ed3fba540f945e950fc8f62f28c7510f737da8 # v1.24
       with:
         ends-with: |
           <!-- tag-license-comment -->

--- a/.github/workflows/dash.yml
+++ b/.github/workflows/dash.yml
@@ -102,7 +102,7 @@ jobs:
         GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
     
     # Hide outdated License comments
-    - uses: int128/hide-comment-action@31ed3fba540f945e950fc8f62f28c7510f737da8 # v1.24
+    - uses: int128/hide-comment-action@31ed3fba540f945e950fc8f62f28c7510f737da8 # v1.24.0
       with:
         ends-with: |
           <!-- tag-license-comment -->

--- a/.github/workflows/dash.yml
+++ b/.github/workflows/dash.yml
@@ -1,0 +1,171 @@
+# *************************************************************************
+# * Copyright (c) 2022, 2023 Hannes Wellmann and others.
+# *
+# * This program and the accompanying materials are made available under
+# * the terms of the Eclipse Public License 2.0 which accompanies this
+# * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+# *
+# * SPDX-License-Identifier: EPL-2.0
+# *      Hannes Wellmann - initial API and implementation
+# *************************************************************************
+# Adapted from https://github.com/eclipse/dash-licenses/blob/master/.github/workflows/mavenLicenseCheck.yml
+# for usage in Eclipse SET
+# 
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  workflow_call:
+    inputs:
+      projectId:
+        description: 'The "projectId" used when license vetting is requested'
+        type: string
+        required: false
+        default: 'technology.set'
+      pom:
+        description: 'The path to the pom.xml'
+        type: string
+        required: false
+        default: 'pom.xml'
+    secrets:
+      gitlabAPIToken:
+        description: 'The authentication token (scope: api) from gitlab.eclipse.org of the calling repository. Only required if license vetting is requested'
+        required: false
+
+jobs:
+  check-licenses:
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && (contains(github.event.comment.body, '/request-license-review') || contains(github.event.comment.body, '/license-check')))
+    
+    # Run on all non-comment events specified by the calling workflow and for comments on PRs that have a corresponding body.
+    runs-on: ubuntu-22.04
+    steps:
+
+    - name: Check dependabot PR 
+      run: echo "isDependabotPR=1" >> $GITHUB_ENV
+      if: >
+        github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
+        && github.actor == 'dependabot[bot]' && github.actor_id == '49699333'
+      # For 'issue_comment'-events this job only runs if a comment was added to a PR with body specified above
+
+    - name: Set review request
+      run: echo "request-review=1" >> $GITHUB_ENV
+      if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/request-license-review')) || env.isDependabotPR
+    
+    - name: Set license check
+      run: echo "license-check=1" >> $GITHUB_ENV
+      if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/license-check')) || env.isDependabotPR
+
+    - name: Process license-vetting request
+      if: (env.request-review || env.license-check) && (!env.isDependabotPR)
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const payload = await github.rest.repos.getCollaboratorPermissionLevel({
+            ...context.repo, username: context.actor
+          });
+          const userPermission = payload?.data?.permission;
+          let reaction = 'rocket'
+          if (!(userPermission == 'write' || userPermission == 'admin')) { // not a committer
+            // Not a committer -> abort workflow
+            core.setFailed("Only committers are permitted to request license vetting and " + context.actor + " isn't one.")
+            reaction = '-1'
+          }
+          // react on comment to give early feedback that the request was understood
+          await github.rest.reactions.createForIssueComment({
+            ...context.repo, comment_id: context.payload?.comment?.id, content: reaction
+          });
+
+    # By default the git-ref checked out for events triggered by comments to PRs is 'refs/heads/master'
+    # and for events triggered by PR creation/updates the ref is 'refs/pull/<PR-number>/merge'.
+    # So by default only the master-branch would be considered when requesting license-reviews, but we want the PR's state.
+    # Unless the PR is closed, then we want the master-branch, which allows subsequent license review requests.
+    - uses: actions/checkout@v3
+      # use default ref 'refs/pull/<PR-number>/merge' for PR-events and 'refs/heads/master' for comments if the PR is closed
+      if: github.event.issue.pull_request == '' || github.event.issue.state != 'open'
+      with:
+        submodules: ${{ inputs.submodules }}
+    - uses: actions/checkout@v3
+      with:
+        ref: 'refs/pull/${{ github.event.issue.number }}/merge'
+        submodules: ${{ inputs.submodules }}
+      if: github.event.issue.pull_request != '' && github.event.issue.state == 'open'
+    
+    - name: Check license vetting status (and ask for review if requested)
+      id: check-license-vetting
+      uses: eclipse-set/build/.github/actions/dash-license-check-action@main
+      with:
+        request-review: ${{ env.request-review }}
+        project-id: ${{ inputs.projectId }}
+        pom: ${{ inputs.pom }}
+      env:
+        GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
+    
+    # Hide outdated License comments
+    - uses: int128/hide-comment-action@5aa4ad6cf762098ebdc5d3c046e9e1fb35fe5ce8 # v1
+      with:
+        ends-with: |
+          <!-- tag-license-comment -->
+
+    - name: Process license check results
+      if: always() 
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs')
+          const reviewRequested = ${{ env.request-review || false }}
+          const updateRequested = reviewRequested || ${{ env.license-check || false }}
+          const licensesVetted = ${{ steps.check-license-vetting.outputs.licenses-vetted }}
+
+          let commentBody = "### License summary\n"
+          if (licensesVetted)
+          {
+            if(updateRequested)
+            {
+              commentBody += ':heavy_check_mark: All licenses already successfully vetted.\n'
+            }
+            else 
+            {
+              // Do not comment if all licenses are vetted and no update was requested 
+              core.info('All licenses are already vetted.')
+              return;
+            }
+          }
+          else 
+          {
+            const reviewSummaryFile = 'DEPENDENCIES'
+            core.info("Read review summary at " + reviewSummaryFile)
+            let content = "";
+            if (fs.existsSync(reviewSummaryFile)) {
+              content = fs.readFileSync(reviewSummaryFile, { encoding: 'utf8' }).trim();
+            }
+
+            if (content) { // not empty
+              commentBody += ":x: Not yet vetted dependencies:\n"
+              commentBody += "| Dependency | License | Status | Ticket |\n"
+              commentBody += "|------------|---------|--------|--------|\n"
+              const lines = content.split('\n')
+              for (const line of lines) {
+                if(line.includes('restricted')) {
+                  commentBody += `| ${line.split(", ").join(" | ")} |\n`
+                }
+              }
+              commentBody += '\n\n- Committers can request a license review via by commenting `/request-license-review`.\n- After all reviews have concluded, Committers can re-run the license-vetting check by commenting `/license-check`\n'
+
+            } else {
+              core.setFailed("License vetting build failed, but no reviews are created")
+              commentBody += ':warning: Failed to request review of not vetted licenses.\n'
+            }
+          }
+
+          commentBody += `\nWorkflow run (with attached summary files):\n${context.serverUrl}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.runId}`
+          commentBody += '\n<!-- tag-license-comment -->'
+          github.rest.issues.createComment({
+            issue_number: context.issue.number, ...context.repo, body: commentBody
+          })
+    
+    - uses: actions/upload-artifact@v3
+      if: always() 
+      with:
+        name: '${{ inputs.projectId }}-license-vetting-summary'
+        path: DEPENDENCIES

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Bump versions
       uses: eclipse-set/build/.github/actions/set-version@main
       with:
-        version: ${{ inputs.version }}.0-SNAPSHOT
+        version: ${{ inputs.version }}.1-SNAPSHOT
         target: ${{ inputs.target }}
      
     - name: Push to Github

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Bump versions
       uses: eclipse-set/build/.github/actions/set-version@main
       with:
-        version: ${{ inputs.version }}.1-SNAPSHOT
+        version: ${{ inputs.version }}.0-SNAPSHOT
         target: ${{ inputs.target }}
      
     - name: Push to Github

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,31 @@
+name: Update DEPENDENCIES file
+    
+on:
+  workflow_call:
+    inputs:
+      pom:
+        description: 'Path to pom.xml'
+        type: string
+        required: false
+        default: 'pom.xml'
+
+jobs:        
+  release-tag:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write  
+    - uses: actions/checkout@v3
+
+    - name: Bump versions
+      uses: eclipse-set/build/.github/actions/update-dependency-file@main
+      with:
+        pom: ${{ inputs.pom }}
+     
+    - name: Push to Github
+      run: |
+        git config user.name 'eclipse-set-bot'
+        git config user.email 'set-bot@eclipse.org'
+        git status
+        git add DEPENDENCIES || true
+        git commit -m "Update DEPENDENCIES" || true
+        git push || true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Bump versions
+    - name: Update DEPENDENCIES
       uses: eclipse-set/build/.github/actions/update-dependency-file@main
       with:
         pom: ${{ inputs.pom }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write  
+    steps:
     - uses: actions/checkout@v3
 
     - name: Bump versions


### PR DESCRIPTION
This PR provides two new reusable workflows

- dash.yml Provides license verification for PRs
- update-dependencies.yml updates the `DEPENDENCIES` file. This is to be used for development branches to update license information during development. 

Also the existing `set-version` action is updated to also update the `DEPENDENCIES` file whenever a release branch/tag is created.