### PR TITLE
Only update DEPENDENCIES for tag creation

### DIFF
--- a/.github/actions/set-version/action.yml
+++ b/.github/actions/set-version/action.yml
@@ -37,8 +37,3 @@ runs:
           -u "/target/locations/location/repositories/repository/url[starts-with(., 'https://maven.pkg.github.com/eclipse-set/')]" \
           -x 'concat("https://maven.pkg.github.com/${{ github.repository_owner }}/", substring-after(., "https://maven.pkg.github.com/eclipse-set/"))' \
           ${{ inputs.target }}
-
-    - name: Update DEPENDENCIES
-      uses: eclipse-set/build/.github/actions/update-dependency-file@main
-      with:
-        pom: ${{ inputs.pom }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -42,7 +42,12 @@ jobs:
         version: ${{ inputs.version }}
         target: ${{ inputs.target }}
         pom: ${{ inputs.pom }}
-     
+
+    - name: Update DEPENDENCIES
+      uses: eclipse-set/build/.github/actions/update-dependency-file@main
+      with:
+        pom: ${{ inputs.pom }}        
+
     - name: Push to Github
       run: |
         git config user.name 'eclipse-set-bot'


### PR DESCRIPTION
Updating it in branch creation requires branches from other repositories to be already built