### PR TITLE
Fix .deps files not being tracked

### DIFF
--- a/utils/license-maven-plugin/pom.xml
+++ b/utils/license-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.set</groupId>
     <artifactId>license-maven-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <packaging>maven-plugin</packaging>
     <properties>

--- a/utils/license-maven-plugin/src/main/java/org/eclipse/set/licensemavenplugin/ExtraDependencies.java
+++ b/utils/license-maven-plugin/src/main/java/org/eclipse/set/licensemavenplugin/ExtraDependencies.java
@@ -51,7 +51,7 @@ public class ExtraDependencies {
 	public static Collection<? extends IContentId> getExtraDependencies() {
 		try {
 			return Files.find(Paths.get("."), 100, (path, attrs) -> attrs.isRegularFile())
-			.filter(p -> p.endsWith(".deps") || p.getFileName().toString().equals("package-lock.json"))
+			.filter(p -> p.toString().endsWith(".deps") || p.getFileName().toString().equals("package-lock.json"))
 			.map(ExtraDependencies::getDependencies)
 			.flatMap(Collection::stream)
 			.toList();


### PR DESCRIPTION
Path.endsWith actually checks for the filename (e.g.  "a/b/c.deps" endsWith "c.deps", but not with "deps"). 