### PR TITLE
Sign and deploy releases to download.eclipse.org

### DIFF
--- a/ci/deploy-release/Jenkinsfile
+++ b/ci/deploy-release/Jenkinsfile
@@ -11,17 +11,36 @@ pipeline {
     }
 
     parameters {
-        string description: 'Release Version', name: 'ReleaseVersion', trim: true
+        string description: 'Release Version. Format: <major>.<minor>.<patch>', name: 'ReleaseVersion', trim: true
     }
 
 
     stages {
-        stage('Sign Release') {
+        stage('Sign Release & Upload') {
             steps {
                 container('github') {
-                    withCredentials([usernamePassword(credentialsId: 'GitHub-BuildUser', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
-                        sh "gh release download -R eclipse-set/set ${params.ReleaseVersion} -p 'SET-*'"
-                        sh 'find .'
+                    withCredentials([string(credentialsId: 'github-bot-token', variable: 'GITHUB_TOKEN')]) {
+                        sh "gh release download -R eclipse-set/set v${params.ReleaseVersion} -p 'unsigned-Eclipse-SET-${params.ReleaseVersion}.zip'"
+                        sh 'unzip -q SET-*.zip -d set'
+                        dir('set')
+                        {
+                            sh "find . -name 'org.eclipse.set*.jar' | xargs -I % curl --fail -o % -F file=@% https://cbi.eclipse.org/jarsigner/sign"   
+                            sh "zip -r Eclipse-SET-${params.ReleaseVersion}.zip ."
+                            archiveArtifacts artifacts: "Eclipse-SET-${params.ReleaseVersion}.zip", followSymlinks: false
+                            sh "gh release upload -R eclipse-set/set v${params.ReleaseVersion} Eclipse-SET-${params.ReleaseVersion}.zip"
+                            sh "gh release delete-asset -R eclipse-set/set -y unsigned-Eclipse-SET-${params.ReleaseVersion}.zip"
+                        }
+                    }
+                }
+                
+                container('jnlp') {
+                    dir('set')
+                    {
+                        sshagent (['projects-storage.eclipse.org-bot-ssh']) {
+                            sh "ssh -o BatchMode=yes genie.set@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/set/releases/${params.ReleaseVersion}"
+                            sh "ssh -o BatchMode=yes genie.set@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/set/releases/${params.ReleaseVersion}/bin"
+                            sh "scp -o BatchMode=yes -r Eclipse-SET-${params.ReleaseVersion}.zip genie.set@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/set/releases/${params.ReleaseVersion}/bin/"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This allows us to upload releases to download.eclipse.org which are signed with the Eclipse Foundation signing key.

**Notes:**

- This relies on a Github Release existing for the relevant tag
- It requires an attachment called `unsigned-Eclipse-SET-{version}.zip`. I'll update the SET workflow to upload an artifact to corresponding releases for a tag.
- This only signs jar files created by us. It does not sign:
    - Dependencies (not content produced by us)
    - Chromium Binaries (not content produced by us)
    - Browser Binaries (chromium_jni.dll, chromium_subp.exe) (contained within a signed jar)
    - The launcher executable (already signed)


